### PR TITLE
Fix Interfaces for Kibela

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,15 +4,5 @@
     "react",
     "power-assert"
   ],
-  "plugins": [
-    [
-      "babel-plugin-resolver",
-      {
-        "resolveDirs": [
-          "src"
-        ]
-      }
-    ]
-  ],
   "sourceMaps": true
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,5 +8,8 @@
   ],
   "rules": {
     "arrow-body-style": 0
+  },
+  "env": {
+    "mocha": true
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,9 @@
     "import"
   ],
   "rules": {
-    "arrow-body-style": 0
+    "arrow-body-style": 0,
+    "import/extensions": 0,
+    "import/no-extraneous-dependencies": 0,
+    "import/no-unresolved": 0
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,9 +7,6 @@
     "import"
   ],
   "rules": {
-    "arrow-body-style": 0,
-    "import/extensions": 0,
-    "import/no-extraneous-dependencies": 0,
-    "import/no-unresolved": 0
+    "arrow-body-style": 0
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,7 @@
     "arrow-body-style": 0
   },
   "env": {
+    "es6": true,
     "mocha": true
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# react-simple-image [![CircleCI](https://circleci.com/gh/bitjourney/react-simple-image/tree/master.png?style=png)](https://circleci.com/gh/bitjourney/react-simple-image/tree/master)
+# react-simple-image [![CircleCI](https://circleci.com/gh/bitjourney/react-simple-image/tree/master.svg?style=svg)](https://circleci.com/gh/bitjourney/react-simple-image/tree/master)
 
 `react-simple-image` is a React Components of `<img>` tag with cleaner srcset/sizes interface.
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ The `<Image/>` component has two descriptor type:
 
 - `alt - String` : (Required) alt text
 - `className - String` : (Optional) additional className
-- `srcSet - Array` : (Required) src set
-  - `Object`
-    - `key: descriptor - Regexp`: width descriptor (e.g. 360w, 720w) or pixel descriptor (e.g. 1x, 1.5x, or 2x)
-    - `value: src - String`: image paths/urls
+- `srcSet - Object` : (Required) src set
+  - `key: descriptor - Regexp`: width descriptor (e.g. 360w, 720w) or pixel descriptor (e.g. 1x, 1.5x, or 2x)
+  - `value: src - String`: image paths/urls
 - `sizes - Array` : (Optional) sizez set for width descriptor
-  - `size - String`: image size
-  - `mediaCondition - String`: to apply on the image size
+  - `Object`
+    - `size - String`: image size
+    - `mediaCondition - String`: to apply on the image size
 
 Here are some tips:
 
@@ -43,11 +43,11 @@ For more information, please reach out for:
 <Image
   alt='example'
   className='additional-className'
-  srcSet={[
-    {'360w', 'example-small.svg'},
-    {'720w', 'example-middle.svg'},
-    {'1200w', 'example-large.svg'},
-  ]},
+  srcSet={{
+    '360w': 'example-small.svg',
+    '720w': 'example-middle.svg',
+    '1200w': 'example-large.svg',
+  }},
   sizes={[
     {size: '100vw', mediaCondition: '(max-width: 30em)'},
     {size: '50vw', mediaCondition: '(max-width: 50em)'},
@@ -65,11 +65,11 @@ For more information, please reach out for:
 ```jsx
 <Image
   alt='example'
-  srcSet={[
-    {'360w', 'example-small.svg'},
-    {'720w', 'example-middle.svg'},
-    {'1200w', 'example-large.svg'},
-  ]},
+  srcSet={{
+    '360w': 'example-small.svg',
+    '720w': 'example-middle.svg',
+    '1200w': 'example-large.svg',
+  }},
   sizes={[
     {size: '100vw', mediaCondition: '(max-width: 30em)'},
     {size: '50vw', mediaCondition: '(max-width: 50em)'},
@@ -99,10 +99,10 @@ For more information, please reach out for:
 <Image
   alt='example'
   className='additional-className'
-  srcSet={[
-    {'1x', 'example.svg'},
-    {'2x', 'example@2x.svg'},
-  ]},
+  srcSet={{
+    '1x': 'example.svg',
+    '2x': 'example@2x.svg',
+  }},
   />
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# react-simple-image [![CircleCI](https://circleci.com/gh/bitjourney/react-simple-image/tree/master.svg?style=svg)](https://circleci.com/gh/bitjourney/react-simple-image/tree/master)
+# react-simple-image [![CircleCI](https://circleci.com/gh/bitjourney/react-simple-image/tree/master.png?style=png)](https://circleci.com/gh/bitjourney/react-simple-image/tree/master)
 
 `react-simple-image` is a React Components of `<img>` tag with cleaner srcset/sizes interface.
 
@@ -20,6 +20,7 @@ The `<Image/>` component has two descriptor type:
 
 - `alt - String` : (Required) alt text
 - `className - String` : (Optional) additional className
+- `src - String` : (Required) src attribute
 - `srcSet - Object` : (Required) src set
   - `key: descriptor - Regexp`: width descriptor (e.g. 360w, 720w) or pixel descriptor (e.g. 1x, 1.5x, or 2x)
   - `value: src - String`: image paths/urls
@@ -43,10 +44,11 @@ For more information, please reach out for:
 <Image
   alt='example'
   className='additional-className'
+  src='example-small.png',
   srcSet={{
-    '360w': 'example-small.svg',
-    '720w': 'example-middle.svg',
-    '1200w': 'example-large.svg',
+    '360w': 'example-small.png',
+    '720w': 'example-middle.png',
+    '1200w': 'example-large.png',
   }},
   sizes={[
     {size: '100vw', mediaCondition: '(max-width: 30em)'},
@@ -65,10 +67,11 @@ For more information, please reach out for:
 ```jsx
 <Image
   alt='example'
+  src='example-small.png',
   srcSet={{
-    '360w': 'example-small.svg',
-    '720w': 'example-middle.svg',
-    '1200w': 'example-large.svg',
+    '360w': 'example-small.png',
+    '720w': 'example-middle.png',
+    '1200w': 'example-large.png',
   }},
   sizes={[
     {size: '100vw', mediaCondition: '(max-width: 30em)'},
@@ -81,13 +84,13 @@ For more information, please reach out for:
 #### Rendered HTML
 
 ```html
-<img 
-  alt="example" 
-  src="example-small.png" 
-  srcset="example-small.png 360w,example-middle.png 720w,example-large.png 1200w" 
-  sizes="(max-width: 30em) 100vw,(max-width: 50em) 50vw,calc(33vw - 100px)" 
-  data-reactroot="" 
-  data-reactid="1" 
+<img
+  alt="example"
+  src="example-small.png"
+  srcset="example-small.png 360w,example-middle.png 720w,example-large.png 1200w"
+  sizes="(max-width: 30em) 100vw,(max-width: 50em) 50vw,calc(33vw - 100px)"
+  data-reactroot=""
+  data-reactid="1"
   data-react-checksum="1197296813"/>
 ```
 
@@ -99,9 +102,10 @@ For more information, please reach out for:
 <Image
   alt='example'
   className='additional-className'
+  src='example.png',
   srcSet={{
-    '1x': 'example.svg',
-    '2x': 'example@2x.svg',
+    '1x': 'example.png',
+    '2x': 'example@2x.png',
   }},
   />
 ```
@@ -109,13 +113,13 @@ For more information, please reach out for:
 #### Rendered HTML
 
 ```html
-<img 
-  alt="example" 
-  class="additional-className" 
-  src="example.png" 
-  srcset="example.png 1x,example@2x.png 2x" 
-  data-reactroot="" 
-  data-reactid="1" 
+<img
+  alt="example"
+  class="additional-className"
+  src="example.png"
+  srcset="example.png 1x,example@2x.png 2x"
+  data-reactroot=""
+  data-reactid="1"
   data-react-checksum="1897738717"/>
 ```
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "homepage": "https://github.com/bitjourney/react-simple-image#readme",
   "devDependencies": {
     "babel-cli": "^6.14.0",
-    "babel-plusin-resolver": "^1.1.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-power-assert": "^1.0.0",
     "babel-preset-react": "^6.11.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "mocha --opts spec/mocha.opts  spec/**/*.spec.jsx",
     "lint": "eslint src/**/*.{js,jsx} spec/**/*.{js,jsx}",
-    "build": "babel src --out-dir lib --source-map"
+    "build": "babel src --out-dir lib --source-maps"
   },
   "files" : [
     "lib",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/bitjourney/react-simple-image#readme",
   "devDependencies": {
     "babel-cli": "^6.14.0",
-    "babel-plugin-resolver": "^1.1.0",
+    "babel-plusin-resolver": "^1.1.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-power-assert": "^1.0.0",
     "babel-preset-react": "^6.11.1",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "responsive <img> tag with cleaner srcset/sizes interface.",
   "main": "lib/image.js",
   "scripts": {
-    "test": "$(npm bin)/mocha --opts spec/mocha.opts  spec/**/*.spec.jsx",
-    "lint": "$(npm bin)/eslint src/**/*.{js,jsx} spec/**/*.{js,jsx}",
+    "test": "mocha --opts spec/mocha.opts  spec/**/*.spec.jsx",
+    "lint": "eslint src/**/*.{js,jsx} spec/**/*.{js,jsx}",
     "build": "babel src --out-dir lib --source-map"
   },
   "files" : [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/bitjourney/react-responsive-img.git"
+    "url": "git+https://github.com/bitjourney/react-simple-image.git"
   },
   "keywords": [
     "HTML5"
@@ -22,9 +22,9 @@
   "author": "kenju",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/bitjourney/react-responsive-img/issues"
+    "url": "https://github.com/bitjourney/react-simple-image/issues"
   },
-  "homepage": "https://github.com/bitjourney/react-responsive-img#readme",
+  "homepage": "https://github.com/bitjourney/react-simple-image#readme",
   "devDependencies": {
     "babel-cli": "^6.14.0",
     "babel-plugin-resolver": "^1.1.0",

--- a/spec/image.spec.jsx
+++ b/spec/image.spec.jsx
@@ -1,4 +1,3 @@
-/* eslint no-undef: 0 */
 import assert from 'power-assert';
 import { renderToString } from 'react-dom/server';
 import { createElement } from 'react';

--- a/spec/image.spec.jsx
+++ b/spec/image.spec.jsx
@@ -3,8 +3,6 @@ import { renderToString } from 'react-dom/server';
 import { createElement } from 'react';
 /* eslint no-undef: 0 */
 
-// eslint-disable-next-line max-len
-// eslint-disable-next-line import/extensions, import/no-extraneous-dependencies, import/no-unresolved
 import Image from 'image';
 
 describe('Image', () => {

--- a/spec/image.spec.jsx
+++ b/spec/image.spec.jsx
@@ -1,8 +1,7 @@
+/* eslint no-undef: 0 */
 import assert from 'power-assert';
 import { renderToString } from 'react-dom/server';
 import { createElement } from 'react';
-/* eslint no-undef: 0 */
-
 import Image from 'image';
 
 describe('Image', () => {

--- a/spec/image.spec.jsx
+++ b/spec/image.spec.jsx
@@ -12,11 +12,11 @@ describe('Image', () => {
     it('should render an expected html string without sizes option', () => {
       const props = {
         alt: 'example',
-        srcSet: [
-          { '360w': 'example-small.png' },
-          { '720w': 'example-middle.png' },
-          { '1200w': 'example-large.png' },
-        ],
+        srcSet: {
+          '360w': 'example-small.png',
+          '720w': 'example-middle.png',
+          '1200w': 'example-large.png',
+        },
       };
       const html = renderToString(createElement(Image, props));
       assert(html.startsWith('<img'));
@@ -28,11 +28,11 @@ describe('Image', () => {
     it('should render an expected html string without option', () => {
       const props = {
         alt: 'example',
-        srcSet: [
-          { '360w': 'example-small.png' },
-          { '720w': 'example-middle.png' },
-          { '1200w': 'example-large.png' },
-        ],
+        srcSet: {
+          '360w': 'example-small.png',
+          '720w': 'example-middle.png',
+          '1200w': 'example-large.png',
+        },
         sizes: [
           { size: '100vw', mediaCondition: '(max-width: 30em)' },
           { size: '50vw', mediaCondition: '(max-width: 50em)' },
@@ -53,10 +53,10 @@ describe('Image', () => {
       const props = {
         alt: 'example',
         className: 'additional-className',
-        srcSet: [
-          { '1x': 'example.png' },
-          { '2x': 'example@2x.png' },
-        ],
+        srcSet: {
+          '1x': 'example.png',
+          '2x': 'example@2x.png',
+        },
       };
       const html = renderToString(createElement(Image, props));
       assert(html.startsWith('<img'));
@@ -69,10 +69,10 @@ describe('Image', () => {
     it('should not render an expected html string with sizes', () => {
       const props = {
         alt: 'example',
-        srcSet: [
-          { '1x': 'example.png' },
-          { '2x': 'example@2x.png' },
-        ],
+        srcSet: {
+          '1x': 'example.png',
+          '2x': 'example@2x.png',
+        },
         sizes: [
           { size: '100vw', mediaCondition: '(max-width: 30em)' },
           { size: '50vw', mediaCondition: '(max-width: 50em)' },
@@ -92,12 +92,12 @@ describe('Image', () => {
     it('should render pixel descriptor and not render width descriptor', () => {
       const props = {
         alt: 'example',
-        srcSet: [
-          { '360w': 'example-small.png' },
-          { '720w': 'example-middle.png' },
-          { '1x': 'example.png' },
-          { '2x': 'example@2x.png' },
-        ],
+        srcSet: {
+          '360w': 'example-small.png',
+          '720w': 'example-middle.png',
+          '1x': 'example.png',
+          '2x': 'example@2x.png',
+        },
       };
       const html = renderToString(createElement(Image, props));
       assert(html.startsWith('<img'));
@@ -112,9 +112,9 @@ describe('Image', () => {
     it('should throw error into console', () => {
       const props = {
         alt: 'example',
-        srcSet: [
-          { invalid: 'example.png' },
-        ],
+        srcSet: {
+          invalid: 'example.png',
+        },
       };
       const html = renderToString(createElement(Image, props));
       /*

--- a/spec/image.spec.jsx
+++ b/spec/image.spec.jsx
@@ -2,7 +2,7 @@
 import assert from 'power-assert';
 import { renderToString } from 'react-dom/server';
 import { createElement } from 'react';
-import Image from 'image';
+import Image from '../src/image';
 
 describe('Image', () => {
   describe('with width descriptor', () => {

--- a/spec/image.spec.jsx
+++ b/spec/image.spec.jsx
@@ -8,6 +8,7 @@ describe('Image', () => {
     it('should render an expected html string without sizes option', () => {
       const props = {
         alt: 'example',
+        src: 'example-small.png',
         srcSet: {
           '360w': 'example-small.png',
           '720w': 'example-middle.png',
@@ -24,6 +25,7 @@ describe('Image', () => {
     it('should render an expected html string without option', () => {
       const props = {
         alt: 'example',
+        src: 'example-small.png',
         srcSet: {
           '360w': 'example-small.png',
           '720w': 'example-middle.png',
@@ -49,6 +51,7 @@ describe('Image', () => {
       const props = {
         alt: 'example',
         className: 'additional-className',
+        src: 'example.png',
         srcSet: {
           '1x': 'example.png',
           '2x': 'example@2x.png',
@@ -65,6 +68,7 @@ describe('Image', () => {
     it('should not render an expected html string with sizes', () => {
       const props = {
         alt: 'example',
+        src: 'example.png',
         srcSet: {
           '1x': 'example.png',
           '2x': 'example@2x.png',
@@ -88,6 +92,7 @@ describe('Image', () => {
     it('should render pixel descriptor and not render width descriptor', () => {
       const props = {
         alt: 'example',
+        src: 'example-small.png',
         srcSet: {
           '360w': 'example-small.png',
           '720w': 'example-middle.png',
@@ -108,6 +113,7 @@ describe('Image', () => {
     it('should throw error into console', () => {
       const props = {
         alt: 'example',
+        src: 'example.png',
         srcSet: {
           invalid: 'example.png',
         },

--- a/spec/image.spec.jsx
+++ b/spec/image.spec.jsx
@@ -3,6 +3,8 @@ import { renderToString } from 'react-dom/server';
 import { createElement } from 'react';
 /* eslint no-undef: 0 */
 
+// eslint-disable-next-line max-len
+// eslint-disable-next-line import/extensions, import/no-extraneous-dependencies, import/no-unresolved
 import Image from 'image';
 
 describe('Image', () => {

--- a/spec/image.spec.jsx
+++ b/spec/image.spec.jsx
@@ -64,7 +64,7 @@ describe('Image', () => {
       assert(html.includes(' srcset="example.png 1x,example@2x.png 2x" '));
     });
 
-    it('should not render an expected html string with sizez', () => {
+    it('should not render an expected html string with sizes', () => {
       const props = {
         alt: 'example',
         srcSet: [

--- a/spec/matcher.spec.jsx
+++ b/spec/matcher.spec.jsx
@@ -1,8 +1,6 @@
 import assert from 'power-assert';
 /* eslint no-undef: 0 */
 
-// eslint-disable-next-line max-len
-// eslint-disable-next-line import/extensions, import/no-extraneous-dependencies, import/no-unresolved
 import Matcher from 'matcher';
 
 describe('Matcher', () => {

--- a/spec/matcher.spec.jsx
+++ b/spec/matcher.spec.jsx
@@ -1,6 +1,6 @@
 /* eslint no-undef: 0 */
 import assert from 'power-assert';
-import Matcher from 'matcher';
+import Matcher from '../src/matcher';
 
 describe('Matcher', () => {
   const validWidths = [

--- a/spec/matcher.spec.jsx
+++ b/spec/matcher.spec.jsx
@@ -1,4 +1,3 @@
-/* eslint no-undef: 0 */
 import assert from 'power-assert';
 import Matcher from '../src/matcher';
 

--- a/spec/matcher.spec.jsx
+++ b/spec/matcher.spec.jsx
@@ -1,6 +1,8 @@
 import assert from 'power-assert';
 /* eslint no-undef: 0 */
 
+// eslint-disable-next-line max-len
+// eslint-disable-next-line import/extensions, import/no-extraneous-dependencies, import/no-unresolved
 import Matcher from 'matcher';
 
 describe('Matcher', () => {

--- a/spec/matcher.spec.jsx
+++ b/spec/matcher.spec.jsx
@@ -1,6 +1,5 @@
-import assert from 'power-assert';
 /* eslint no-undef: 0 */
-
+import assert from 'power-assert';
 import Matcher from 'matcher';
 
 describe('Matcher', () => {

--- a/spec/matcher.spec.jsx
+++ b/spec/matcher.spec.jsx
@@ -1,5 +1,5 @@
 import assert from 'power-assert';
-import Matcher from '../src/matcher';
+import { matchDescriptor, matchWidthDescriptor, matchPixelDescriptor } from '../src/matcher';
 
 describe('Matcher', () => {
   const validWidths = [
@@ -36,34 +36,34 @@ describe('Matcher', () => {
   describe('#matchDescriptor', () => {
     it('should match with both width and pixel descriptor', () => {
       validWidths.concat(validPixels)
-        .map(str => assert(Matcher.matchDescriptor(str)));
+        .map(str => assert(matchDescriptor(str)));
     });
 
     it('should not match with invalid descriptor', () => {
       invalidDescriptor.concat(invalidPixels, invalidWidths)
-        .map(str => assert(!Matcher.matchDescriptor(str)));
+        .map(str => assert(!matchDescriptor(str)));
     });
   });
 
   describe('#matchWidthDescriptor', () => {
     it('should match with width descriptor', () => {
-      validWidths.map(str => assert(Matcher.matchWidthDescriptor(str)));
+      validWidths.map(str => assert(matchWidthDescriptor(str)));
     });
 
     it('should not match with invalid descriptor', () => {
       invalidDescriptor.concat(validPixels, invalidWidths)
-        .map(str => assert(!Matcher.matchWidthDescriptor(str)));
+        .map(str => assert(!matchWidthDescriptor(str)));
     });
   });
 
   describe('#matchPixelDescriptor', () => {
     it('should match with pixel descriptor', () => {
-      validPixels.map(str => assert(Matcher.matchPixelDescriptor(str)));
+      validPixels.map(str => assert(matchPixelDescriptor(str)));
     });
 
     it('should not match with invalid descriptor', () => {
       invalidDescriptor.concat(validWidths, invalidPixels)
-        .map(str => assert(!Matcher.matchPixelDescriptor(str)));
+        .map(str => assert(!matchPixelDescriptor(str)));
     });
   });
 });

--- a/src/image.jsx
+++ b/src/image.jsx
@@ -6,6 +6,7 @@ export default class Image extends React.Component {
     return {
       alt: React.PropTypes.string.isRequired,
       className: React.PropTypes.string,
+      src: React.PropTypes.string.isRequired,
       srcSet: React.PropTypes.objectOf((props, propName, componentName) => {
         if (!matchDescriptor(propName)) {
           return new Error(`Invalid prop '${propName}' supplied to '${componentName}'. Validation failed.`);
@@ -26,18 +27,6 @@ export default class Image extends React.Component {
         return matchWidthDescriptor(descriptor);
       }),
     };
-  }
-
-  getSrc() {
-    /*
-     * TODO: object properties does not specify order,
-     * so the result could change for each browser implementation.
-     *
-     * see discussion below:
-     * https://github.com/bitjourney/react-simple-image/pull/4/files#r94013960
-     */
-    const firstSrcSetKey = Object.keys(this.props.srcSet)[0];
-    return this.props.srcSet[firstSrcSetKey];
   }
 
   buildSrcSet() {
@@ -64,7 +53,7 @@ export default class Image extends React.Component {
       <img
         alt={this.props.alt}
         className={this.props.className}
-        src={this.getSrc()}
+        src={this.props.src}
         srcSet={this.buildSrcSet()}
         sizes={this.buildSizes()}
       />

--- a/src/image.jsx
+++ b/src/image.jsx
@@ -43,7 +43,7 @@ export default class Image extends React.Component {
   buildSrcSet() {
     const matcher = this.state.widthDescriptorOnly ? matchWidthDescriptor : matchPixelDescriptor;
     return Object.keys(this.props.srcSet)
-      .filter(descriptor => matcher.call(this, descriptor))
+      .filter(matcher)
       .map(descriptor => `${this.props.srcSet[descriptor]} ${descriptor}`);
   }
 

--- a/src/image.jsx
+++ b/src/image.jsx
@@ -32,7 +32,9 @@ export default class Image extends React.Component {
     /*
      * TODO: object properties does not specify order,
      * so the result could change for each browser implementation.
-     * Adding 'src' props (optional) would be nice idea?
+     *
+     * see discussion below:
+     * https://github.com/bitjourney/react-simple-image/pull/4/files#r94013960
      */
     const firstSrcSetKey = Object.keys(this.props.srcSet)[0];
     return this.props.srcSet[firstSrcSetKey];

--- a/src/image.jsx
+++ b/src/image.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Matcher from './matcher';
+import Matcher from 'matcher';
 
 export default class Image extends React.Component {
   static get propTypes() {

--- a/src/image.jsx
+++ b/src/image.jsx
@@ -6,12 +6,12 @@ export default class Image extends React.Component {
     return {
       alt: React.PropTypes.string.isRequired,
       className: React.PropTypes.string,
-      srcSet: React.PropTypes.arrayOf(React.PropTypes.objectOf((props, propName, componentName) => {
+      srcSet: React.PropTypes.objectOf((props, propName, componentName) => {
         if (!Matcher.matchDescriptor(propName)) {
           return new Error(`Invalid prop '${propName}' supplied to '${componentName}'. Validation failed.`);
         }
         return null;
-      })),
+      }),
       sizes: React.PropTypes.arrayOf(React.PropTypes.shape({
         size: React.PropTypes.string.isRequired,
         mediaCondition: React.PropTypes.string,
@@ -22,33 +22,26 @@ export default class Image extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      widthDescriptorOnly: this.props.srcSet.every((srcSet) => {
-        return Object.keys(srcSet).every((descriptor) => {
-          return Matcher.matchWidthDescriptor(descriptor);
-        });
+      widthDescriptorOnly: Object.keys(this.props.srcSet).every((descriptor) => {
+        return Matcher.matchWidthDescriptor(descriptor);
       }),
     };
   }
 
   getSrc() {
-    const firstSrcSet = this.props.srcSet[0];
-    const key = Object.keys(firstSrcSet)[0];
-    return firstSrcSet[key];
+    const firstSrcSetKey = Object.keys(this.props.srcSet)[0];
+    return this.props.srcSet[firstSrcSetKey];
   }
 
   buildSrcSet() {
     const matcher = this.state.widthDescriptorOnly
-          ? Matcher.matchWidthDescriptor : Matcher.matchPixelDescriptor;
-    return this.props.srcSet
-                .filter((srcSet) => {
-                  return Object.keys(srcSet).every((descriptor) => {
-                    return matcher.call(this, descriptor);
-                  });
-                }).map((srcSet) => {
-                  return Object.keys(srcSet).map((descriptor) => {
-                    return `${srcSet[descriptor]} ${descriptor}`;
-                  });
-                });
+      ? Matcher.matchWidthDescriptor : Matcher.matchPixelDescriptor;
+    return Object.keys(this.props.srcSet)
+      .filter((descriptor) => {
+        return matcher.call(this, descriptor);
+      }).map((descriptor) => {
+        return `${this.props.srcSet[descriptor]} ${descriptor}`;
+      });
   }
 
   buildSizes() {

--- a/src/image.jsx
+++ b/src/image.jsx
@@ -6,12 +6,12 @@ export default class Image extends React.Component {
     return {
       alt: React.PropTypes.string.isRequired,
       className: React.PropTypes.string,
-      srcSet: React.PropTypes.arrayOf((props, propName, componentName) => {
+      srcSet: React.PropTypes.arrayOf(React.PropTypes.objectOf((props, propName, componentName) => {
         if (!Matcher.matchDescriptor(propName)) {
           return new Error(`Invalid prop '${propName}' supplied to '${componentName}'. Validation failed.`);
         }
         return null;
-      }),
+      })),
       sizes: React.PropTypes.arrayOf(React.PropTypes.shape({
         size: React.PropTypes.string.isRequired,
         mediaCondition: React.PropTypes.string,

--- a/src/image.jsx
+++ b/src/image.jsx
@@ -37,11 +37,8 @@ export default class Image extends React.Component {
     const matcher = this.state.widthDescriptorOnly
       ? Matcher.matchWidthDescriptor : Matcher.matchPixelDescriptor;
     return Object.keys(this.props.srcSet)
-      .filter((descriptor) => {
-        return matcher.call(this, descriptor);
-      }).map((descriptor) => {
-        return `${this.props.srcSet[descriptor]} ${descriptor}`;
-      });
+      .filter(descriptor => matcher.call(this, descriptor))
+      .map(descriptor => `${this.props.srcSet[descriptor]} ${descriptor}`);
   }
 
   buildSizes() {

--- a/src/image.jsx
+++ b/src/image.jsx
@@ -32,11 +32,7 @@ export default class Image extends React.Component {
     /*
      * TODO: object properties does not specify order,
      * so the result could change for each browser implementation.
-     * Using Map would be simple alternative.
-     *
-     * @see
-     * https://www.ecma-international.org/ecma-262/5.1/#sec-15.2.3.14
-     * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#Objects_and_maps_compared
+     * Adding 'src' props (optional) would be nice idea?
      */
     const firstSrcSetKey = Object.keys(this.props.srcSet)[0];
     return this.props.srcSet[firstSrcSetKey];

--- a/src/image.jsx
+++ b/src/image.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Matcher from 'matcher';
+import Matcher from './matcher';
 
 export default class Image extends React.Component {
   static get propTypes() {

--- a/src/image.jsx
+++ b/src/image.jsx
@@ -29,6 +29,15 @@ export default class Image extends React.Component {
   }
 
   getSrc() {
+    /*
+     * TODO: object properties does not specify order,
+     * so the result could change for each browser implementation.
+     * Using Map would be simple alternative.
+     *
+     * @see
+     * https://www.ecma-international.org/ecma-262/5.1/#sec-15.2.3.14
+     * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#Objects_and_maps_compared
+     */
     const firstSrcSetKey = Object.keys(this.props.srcSet)[0];
     return this.props.srcSet[firstSrcSetKey];
   }

--- a/src/image.jsx
+++ b/src/image.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Matcher from './matcher';
+import { matchDescriptor, matchWidthDescriptor, matchPixelDescriptor } from '../src/matcher';
 
 export default class Image extends React.Component {
   static get propTypes() {
@@ -7,7 +7,7 @@ export default class Image extends React.Component {
       alt: React.PropTypes.string.isRequired,
       className: React.PropTypes.string,
       srcSet: React.PropTypes.objectOf((props, propName, componentName) => {
-        if (!Matcher.matchDescriptor(propName)) {
+        if (!matchDescriptor(propName)) {
           return new Error(`Invalid prop '${propName}' supplied to '${componentName}'. Validation failed.`);
         }
         return null;
@@ -23,7 +23,7 @@ export default class Image extends React.Component {
     super(props);
     this.state = {
       widthDescriptorOnly: Object.keys(this.props.srcSet).every((descriptor) => {
-        return Matcher.matchWidthDescriptor(descriptor);
+        return matchWidthDescriptor(descriptor);
       }),
     };
   }
@@ -41,8 +41,7 @@ export default class Image extends React.Component {
   }
 
   buildSrcSet() {
-    const matcher = this.state.widthDescriptorOnly
-      ? Matcher.matchWidthDescriptor : Matcher.matchPixelDescriptor;
+    const matcher = this.state.widthDescriptorOnly ? matchWidthDescriptor : matchPixelDescriptor;
     return Object.keys(this.props.srcSet)
       .filter(descriptor => matcher.call(this, descriptor))
       .map(descriptor => `${this.props.srcSet[descriptor]} ${descriptor}`);

--- a/src/matcher.jsx
+++ b/src/matcher.jsx
@@ -3,16 +3,14 @@ const REGEXP_DESCRIPTOR_WIDTH = new RegExp(`^${REGEXP_DECIMAL_NUMBER.source}w$`)
 const REGEXP_DESCRIPTOR_PIXEL = new RegExp(`^${REGEXP_DECIMAL_NUMBER.source}x$`);
 const REGEXP_DESCRIPTOR_WIDTH_AND_PIXEL = new RegExp(`^${REGEXP_DECIMAL_NUMBER.source}[wx]$`);
 
-export default class Matcher {
-  static matchWidthDescriptor(str) {
-    return REGEXP_DESCRIPTOR_WIDTH.test(str);
-  }
+export function matchWidthDescriptor(str) {
+  return REGEXP_DESCRIPTOR_WIDTH.test(str);
+}
 
-  static matchPixelDescriptor(str) {
-    return REGEXP_DESCRIPTOR_PIXEL.test(str);
-  }
+export function matchPixelDescriptor(str) {
+  return REGEXP_DESCRIPTOR_PIXEL.test(str);
+}
 
-  static matchDescriptor(str) {
-    return REGEXP_DESCRIPTOR_WIDTH_AND_PIXEL.test(str);
-  }
+export function matchDescriptor(str) {
+  return REGEXP_DESCRIPTOR_WIDTH_AND_PIXEL.test(str);
 }


### PR DESCRIPTION
Kibelaに組み込むために必要な修正のPRです。

- [x] srcSet propsのインターフェースでArrayでラップしているのが冗長だったため削除
- [x] Custom Validationがconsole warningを吐いていたため修正
- [x] バグの早期検出のためにESLintを組み込み
- [x] `yarn build` で生成するファイルが絶対パスを含み、本体のCIでfailする件の修正