### PR TITLE
Update patch version to v0.1.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # The Revision History
 
+## v0.1.2 - 2017/01/04
+
+* Change `src` props interface to required from optional
+* Change `srcSet` props interface to Object from Array<Object>
+* Fix `srcSet` props validation logic
+* Add test-coverage tool (istanbul) for CI
+
 ## v0.1.1 - 2016/12/28
 
 * Add compiled files to the package

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-simple-image",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "responsive <img> tag with cleaner srcset/sizes interface.",
   "main": "lib/image.js",
   "scripts": {


### PR DESCRIPTION
Versionを`v0.1.2` にアップデートします。↓が差分です。

https://github.com/bitjourney/react-simple-image/compare/df5dbbdb189fa69ae8c5efd9f473075e94379ed9...master