### PR TITLE
Don't use exact version in package.json's "engines" section

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepublish": "npm run build"
   },
   "engines": {
-    "node": "6.11.1"
+    "node": ">= 6"
   },
   "files": [
     "lib",


### PR DESCRIPTION
It's because yarn v1.0 validates them.