### PR TITLE
handle empty attrs correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,9 @@
     "test": "NODE_ENV=test mocha",
     "test:coverage": "NODE_ENV=test nyc mocha",
     "coveralls": "NODE_ENV=test nyc report --reporter=text-lcov | $(npm bin)/coveralls",
-    "story:start": "start-storybook -p 9001 -c .storybook",
-    "story:build": "build-storybook -c .storybook -o build",
     "prepublish": "npm run build",
-    "lint": "tslint --type-check --project tsconfig.json",
-    "lint:fix": "tslint --fix --type-check --project tsconfig.json"
+    "lint": "tslint --project tsconfig.json",
+    "lint:fix": "tslint --fix --project tsconfig.json"
   },
   "engines": {
     "node": ">= 6"

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -8,8 +8,8 @@ export interface Size {
 }
 
 export interface Props {
-  alt: string;
   src: string;
+  alt?: string;
   className?: string;
   srcSet?: any;
   sizes?: Size[];
@@ -17,9 +17,10 @@ export interface Props {
 
 export default class Image extends React.PureComponent<Props> {
   static readonly propTypes = {
-    alt: PropTypes.string.isRequired,
-    className: PropTypes.string,
     src: PropTypes.string.isRequired,
+
+    alt: PropTypes.string,
+    className: PropTypes.string,
     srcSet: PropTypes.objectOf((props, propName, componentName) => {
       if (!matchDescriptor(propName)) {
         return new Error(`Invalid prop '${propName}' supplied to '${componentName}'. Validation failed.`);
@@ -31,6 +32,10 @@ export default class Image extends React.PureComponent<Props> {
       mediaCondition: PropTypes.string,
     })),
   };
+
+  static readonly defaultProps = {
+    alt: '', // it indicates this image is not a key part of the content
+  }
 
   readonly widthDescriptorOnly: boolean;
 
@@ -45,7 +50,7 @@ export default class Image extends React.PureComponent<Props> {
     return Object.keys(this.props.srcSet)
       .filter(matcher)
       .map(descriptor => `${this.props.srcSet[descriptor]} ${descriptor}`)
-      .join(',');
+      .join(',') || undefined;
   }
 
   buildSizes() {
@@ -55,9 +60,9 @@ export default class Image extends React.PureComponent<Props> {
           return `${size.mediaCondition} ${size.size}`;
         }
         return `${size.size}`;
-      }).join(',');
+      }).join(',') || undefined;
     }
-    return '';
+    return undefined;
   }
 
   render() {

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -35,7 +35,7 @@ export default class Image extends React.PureComponent<Props> {
 
   static readonly defaultProps = {
     alt: '', // it indicates this image is not a key part of the content
-  }
+  };
 
   readonly widthDescriptorOnly: boolean;
 

--- a/test/Image.spec.tsx
+++ b/test/Image.spec.tsx
@@ -126,4 +126,17 @@ describe('Image', () => {
       assert(html.startsWith('<img'));
     });
   });
+
+  describe('with empty alt', () => {
+    it('should throw error into console', () => {
+      const props = {
+        src: 'example.png',
+        srcSet: {},
+      };
+      const html = renderToString(createElement(Image, props));
+      assert(html.includes('alt=""'));
+      assert(!html.includes('srcSet'));
+      assert(!html.includes('sizes'));
+    });
+  });
 });


### PR DESCRIPTION
* `alt` is now optional
  * cf. https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img
    * > Setting this attribute to an empty string (`alt=""`) indicates that this image is not a key part of the content
* Do not output anything if `sizes` is empty
* Do not output anything if `srcSet` is empty